### PR TITLE
fix: add `types` to the highs-solver package to allow dynamic import in CJS

### DIFF
--- a/packages/highs-solver/package.json
+++ b/packages/highs-solver/package.json
@@ -22,6 +22,7 @@
     ".": "./lib/index.js",
     "./errors": "./lib/index.errors.js"
   },
+  "types": "./lib/index.d.ts",
   "scripts": {
     "build": "tsc -p src",
     "clean": "rm -rf lib node_modules out",


### PR DESCRIPTION
Closes #62.