### PR TITLE
feat: implement getRunTime and zero all clocks at the start of a solve

### DIFF
--- a/packages/highs-addon/index.d.ts
+++ b/packages/highs-addon/index.d.ts
@@ -7,7 +7,6 @@ export declare class Solver {
   setOption(name: string, val: OptionValue): void;
   getOption<N extends keyof TypedOptions>(name: N): TypedOptions[N];
   getOption(name: string): OptionValue;
-  zeroAllClocks(): void;
   getRunTime(): number;
 
   passModel(model: Model): void;

--- a/packages/highs-addon/index.d.ts
+++ b/packages/highs-addon/index.d.ts
@@ -41,6 +41,8 @@ export declare class Solver {
   clear(): void;
   clearModel(): void;
   clearSolver(): void;
+
+  zeroAllClocks(): void;
 }
 
 export type OptionValue = boolean | number | string;

--- a/packages/highs-addon/index.d.ts
+++ b/packages/highs-addon/index.d.ts
@@ -7,7 +7,6 @@ export declare class Solver {
   setOption(name: string, val: OptionValue): void;
   getOption<N extends keyof TypedOptions>(name: N): TypedOptions[N];
   getOption(name: string): OptionValue;
-  getRunTime(): number;
 
   passModel(model: Model): void;
   readModel(fp: string, cb: (err: Error) => void): string;
@@ -26,6 +25,7 @@ export declare class Solver {
   run(cb: (err: Error) => void): void;
   getModelStatus(): ModelStatus;
   getInfo(): Info;
+  getRunTime(): number;
 
   getSolution(): Solution;
   setSolution(

--- a/packages/highs-addon/index.d.ts
+++ b/packages/highs-addon/index.d.ts
@@ -7,6 +7,8 @@ export declare class Solver {
   setOption(name: string, val: OptionValue): void;
   getOption<N extends keyof TypedOptions>(name: N): TypedOptions[N];
   getOption(name: string): OptionValue;
+  zeroAllClocks(): void;
+  getRunTime(): number;
 
   passModel(model: Model): void;
   readModel(fp: string, cb: (err: Error) => void): string;

--- a/packages/highs-addon/src/solver.cc
+++ b/packages/highs-addon/src/solver.cc
@@ -434,12 +434,11 @@ Napi::Value Solver::GetInfo(const Napi::CallbackInfo& info) {
 Napi::Value Solver::GetRunTime(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   int length = info.Length();
-  if (length != 0)
-  {
+  if (length != 0) {
     ThrowTypeError(env, "Expected 0 arguments");
     return env.Undefined();
   }
-  return Napi::Number::New(env, (double)this->highs_->getRunTime());
+  return Napi::Number::New(env, (double) this->highs_->getRunTime());
 }
 
 // Solutions

--- a/packages/highs-addon/src/solver.cc
+++ b/packages/highs-addon/src/solver.cc
@@ -19,7 +19,8 @@ void Solver::Init(Napi::Env env, Napi::Object exports) {
                    InstanceMethod("run", &Solver::Run),
                    InstanceMethod("getModelStatus", &Solver::GetModelStatus),
                    InstanceMethod("getInfo", &Solver::GetInfo),
-
+                   InstanceMethod("getRunTime", &Solver::GetRunTime),
+                   
                    InstanceMethod("getSolution", &Solver::GetSolution),
                    InstanceMethod("setSolution", &Solver::SetSolution),
                    InstanceMethod("writeSolution", &Solver::WriteSolution),
@@ -27,7 +28,9 @@ void Solver::Init(Napi::Env env, Napi::Object exports) {
 
                    InstanceMethod("clearModel", &Solver::ClearModel),
                    InstanceMethod("clearSolver", &Solver::ClearSolver),
-                   InstanceMethod("clear", &Solver::Clear)});
+                   InstanceMethod("clear", &Solver::Clear),
+
+                   InstanceMethod("zeroAllClocks", &Solver::ZeroAllClocks)});
 
   Napi::FunctionReference* constructor = new Napi::FunctionReference();
   *constructor = Napi::Persistent(func);
@@ -428,6 +431,17 @@ Napi::Value Solver::GetInfo(const Napi::CallbackInfo& info) {
   return obj;
 }
 
+Napi::Value Solver::GetRunTime(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  int length = info.Length();
+  if (length != 0)
+  {
+    ThrowTypeError(env, "Expected 0 arguments");
+    return env.Undefined();
+  }
+  return Napi::Number::New(env, (double)this->highs_->getRunTime());
+}
+
 // Solutions
 
 Napi::Value ToFloat64Array(const Napi::Env& env, const std::vector<double>& vec) {
@@ -568,4 +582,14 @@ void Solver::ClearSolver(const Napi::CallbackInfo& info) {
     ThrowError(env, "Clear solver failed");
     return;
   }
+}
+
+void Solver::ZeroAllClocks(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  int length = info.Length();
+  if (length != 0) {
+    ThrowTypeError(env, "Expected 0 arguments");
+    return;
+  }
+  this->highs_->zeroAllClocks();
 }

--- a/packages/highs-addon/src/solver.h
+++ b/packages/highs-addon/src/solver.h
@@ -24,6 +24,7 @@ class Solver : public Napi::ObjectWrap<Solver> {
   void Run(const Napi::CallbackInfo& info);
   Napi::Value GetModelStatus(const Napi::CallbackInfo& info);
   Napi::Value GetInfo(const Napi::CallbackInfo& info);
+  Napi::Value GetRunTime(const Napi::CallbackInfo &info);
 
   Napi::Value GetSolution(const Napi::CallbackInfo& info);
   void SetSolution(const Napi::CallbackInfo& info);
@@ -33,6 +34,8 @@ class Solver : public Napi::ObjectWrap<Solver> {
   void Clear(const Napi::CallbackInfo& info);
   void ClearModel(const Napi::CallbackInfo& info);
   void ClearSolver(const Napi::CallbackInfo& info);
+
+  void ZeroAllClocks(const Napi::CallbackInfo &info);
 
   std::shared_ptr<Highs> highs_;
 };

--- a/packages/highs-addon/test/index.test.ts
+++ b/packages/highs-addon/test/index.test.ts
@@ -224,6 +224,17 @@ describe('solver', () => {
       );
     });
   });
+
+  test('checks solver get run time and zero all solver clocks', async () => {
+    await withSolver(async (solver) => {
+      await p(solver, 'readModel', resourcePath('simple.lp'));
+      expect(solver.getRunTime()).toEqual(0);
+      await p(solver, 'run');
+      expect(solver.getRunTime()).toBeGreaterThan(0);
+      solver.zeroAllClocks();
+      expect(solver.getRunTime()).toEqual(0);
+    });
+  });
 });
 
 function cloneSolution(sol: sut.Solution): sut.Solution {

--- a/packages/highs-solver/src/solver.ts
+++ b/packages/highs-solver/src/solver.ts
@@ -340,7 +340,7 @@ export class Solver {
     return this.solving;
   }
 
-  /** Returns the cumulative wall-clock time spent in the last solve */
+  /** Returns the cumulative wall-clock time spent in the last solve. */
   getRunTime(): number {
     return this.delegated('getRunTime');
   }

--- a/packages/highs-solver/src/solver.ts
+++ b/packages/highs-solver/src/solver.ts
@@ -265,12 +265,16 @@ export class Solver {
     readonly monitor?: SolveMonitor;
     /** Do not throw if the underlying solver exited with non-OPTIMAL status. */
     readonly allowNonOptimal?: boolean;
+    /** If true, the solver will not reset all clocks before solving. */
+    readonly keepClocks?: boolean;
   }): Promise<void> {
     this.assertNotSolving();
     const {telemetry: tel} = this;
     tel.logger.debug('Starting solve...');
 
-    this.delegated('zeroAllClocks');
+    if (opts?.keepClocks !== true) {
+      this.delegated('zeroAllClocks');
+    }
 
     let logPath = this.delegated('getOption', 'log_file');
     assertType('string', logPath);

--- a/packages/highs-solver/src/solver.ts
+++ b/packages/highs-solver/src/solver.ts
@@ -270,6 +270,8 @@ export class Solver {
     const {telemetry: tel} = this;
     tel.logger.debug('Starting solve...');
 
+    this.delegated('zeroAllClocks');
+
     let logPath = this.delegated('getOption', 'log_file');
     assertType('string', logPath);
 
@@ -332,6 +334,11 @@ export class Solver {
   /** Returns true if the solver is currently solving the model. */
   isSolving(): boolean {
     return this.solving;
+  }
+
+  /** Returns the cumulative wall-clock time spent in the last solve */
+  getRunTime(): number {
+    return this.delegated('getRunTime');
   }
 
   /** Returns the current solver status, set from the last solve. */

--- a/packages/highs-solver/src/solver.ts
+++ b/packages/highs-solver/src/solver.ts
@@ -345,6 +345,11 @@ export class Solver {
     return this.delegated('getRunTime');
   }
 
+  /** Reset all internal solver clocks to zero. */
+  zeroAllClocks(): void {
+    this.delegated('zeroAllClocks');
+  }
+
   /** Returns the current solver status, set from the last solve. */
   getStatus(): SolverStatus {
     return asSolverStatus(this.delegated('getModelStatus'));

--- a/packages/highs-solver/test/index.test.ts
+++ b/packages/highs-solver/test/index.test.ts
@@ -94,6 +94,24 @@ describe('solve', () => {
     }
   });
 
+  test('checks solver get run time', async () => {
+    const solver = sut.Solver.create();
+    await solver.setModelFromFile(loader.localUrl('unbounded.mps'));
+    expect(solver.getRunTime()).toEqual(0);
+    await solver.solve({allowNonOptimal: true});
+    expect(solver.getRunTime()).toBeGreaterThan(0);
+  });
+
+  test('zero all solver clocks manually', async () => {
+    const solver = sut.Solver.create();
+    await solver.setModelFromFile(loader.localUrl('unbounded.mps'));
+    expect(solver.getRunTime()).toEqual(0);
+    await solver.solve({allowNonOptimal: true, keepClocks: true});
+    expect(solver.getRunTime()).toBeGreaterThan(0);
+    solver.zeroAllClocks();
+    expect(solver.getRunTime()).toEqual(0);
+  });
+
   test('monitors progress', async () => {
     let progressed = false;
     const monitor = sut.solveMonitor().on('progress', () => {

--- a/packages/highs-solver/test/solver.test.ts
+++ b/packages/highs-solver/test/solver.test.ts
@@ -106,6 +106,24 @@ describe('solver', () => {
       expect(solver.getStatus()).toEqual(sut.SolverStatus.UNBOUNDED);
     });
 
+    test('checks solver get run time', async () => {
+      const solver = sut.Solver.create();
+      await solver.setModelFromFile(loader.localUrl('unbounded.mps'));
+      expect(solver.getRunTime()).toEqual(0);
+      await solver.solve({allowNonOptimal: true});
+      expect(solver.getRunTime()).toBeGreaterThan(0);
+    });
+
+    test('zero all solver clocks manually', async () => {
+      const solver = sut.Solver.create();
+      await solver.setModelFromFile(loader.localUrl('unbounded.mps'));
+      expect(solver.getRunTime()).toEqual(0);
+      await solver.solve({allowNonOptimal: true, keepClocks: true});
+      expect(solver.getRunTime()).toBeGreaterThan(0);
+      solver.zeroAllClocks();
+      expect(solver.getRunTime()).toEqual(0);
+    });
+
     test('throws on empty model', async () => {
       const solver = sut.Solver.create();
       try {


### PR DESCRIPTION
Solves the issue with ever-increasing solver time, which eventually leads to `TIME_LIMIT` as explained in https://github.com/jump-dev/HiGHS.jl/issues/167